### PR TITLE
Improved insertion

### DIFF
--- a/src/cut.js
+++ b/src/cut.js
@@ -2,9 +2,14 @@ import {CanvasManager} from './canvasManager.js';
 import {UserInputManager} from './userInput.js';
 import {getRandomString, DEBUG} from './main.js';
 import {Point} from './lib/point.js';
-import {getEllipseArea, isWithinEllipse, isWithinTollerance} from './lib/math.js';
+import {
+    getEllipseArea, 
+    isWithinEllipse, 
+    isWithinTollerance,
+    getInteriorBoundingBox,
+} from './lib/math.js';
 import {Vector, drawVector} from './lib/vector.js';
-import {renderProofTexture} from './renderer.js';
+import {renderProofTexture, drawPoint} from './renderer.js';
 
 /** @typedef { import('./lib/point.js').Point } Point */
 
@@ -38,6 +43,21 @@ class Cut{
         this.area = getEllipseArea(this.rad_x, this.rad_y);
 
         this.is_proof_selected = false;
+        this.bounding_box = [
+            this.x - this.rad_x, 
+            this.y - this.rad_y,
+            this.rad_x*2,this.rad_y*2
+        ];
+
+        let inner_bb = getInteriorBoundingBox(this.rad_x, this.rad_y);
+        let diff_x = (this.rad_x * 2) - (inner_bb[0] * 2);
+        let diff_y = (this.rad_y * 2) - (inner_bb[1] * 2);
+
+        this.interier_bounding_box = [
+            this.x - this.rad_x + diff_x/2, 
+            this.y - this.rad_y + diff_y/2,
+            inner_bb[0]*2,inner_bb[1]*2
+        ];
     }
 
 
@@ -62,6 +82,22 @@ class Cut{
             }
         }
 
+        this.bounding_box = [
+            this.x - this.rad_x, 
+            this.y - this.rad_y,
+            this.rad_x*2,this.rad_y*2
+        ];
+
+
+        let inner_bb = getInteriorBoundingBox(this.rad_x, this.rad_y);
+        let diff_x = (this.rad_x * 2) - (inner_bb[0] * 2);
+        let diff_y = (this.rad_y * 2) - (inner_bb[1] * 2);
+
+        this.interier_bounding_box = [
+            this.x - this.rad_x + diff_x/2, 
+            this.y - this.rad_y + diff_y/2,
+            inner_bb[0]*2,inner_bb[1]*2
+        ];
     }
 
 
@@ -69,7 +105,7 @@ class Cut{
     * update this cut and its child cuts & syms
     * 
     * @param {Point} new_pos - the new position to move to
-    * @param {Boolean|Null} root - is this the root obj to move or false if getting moved by another
+    * @param {Boolean|null} root - is this the root obj to move or false if getting moved by another
     */
     updatePos( new_pos, root = true ){
         let UM = UserInputManager.getInstance();
@@ -183,7 +219,7 @@ class Cut{
 * @param {Cut} cut
 */
 function drawCut(cut){
-    let CONTEXT = CanvasManager.getInstance().getContext();
+    let context = CanvasManager.getInstance().getContext();
     let UM = UserInputManager.getInstance();
 
     let border_rad = 5;
@@ -192,23 +228,41 @@ function drawCut(cut){
         return;
     }
 
-    CONTEXT.strokeStyle = cut === UM.obj_under_mouse ? 'blue' : 'black';
+    context.strokeStyle = cut === UM.obj_under_mouse ? 'blue' : 'black';
 
     if(cut.is_mouse_in_border && !UM.is_proof_mode){
-        CONTEXT.strokeStyle = "lightblue";
+        context.strokeStyle = "lightblue";
     }
 
-    CONTEXT.lineWidth = cut.border_rad;
+    context.lineWidth = cut.border_rad;
 
-    CONTEXT.beginPath();
-    CONTEXT.ellipse(
+    context.beginPath();
+    context.ellipse(
         cut.x, cut.y, 
         cut.rad_x - cut.border_rad/2, 
         cut.rad_y - cut.border_rad/2, 
         0, 0, 2 * Math.PI
     );
 
-    CONTEXT.stroke();
+    context.stroke();
+
+    if(DEBUG){
+        context.beginPath();
+        context.lineWidth = 2;
+        let bb = cut.bounding_box;
+        context.rect(
+            bb[0],bb[1],bb[2],bb[3]
+        );
+
+        let i_bb = cut.interier_bounding_box;
+       // console.log(bb);
+        context.rect(
+            i_bb[0],i_bb[1],i_bb[2],i_bb[3]
+        );
+        context.stroke();
+    }
+
+
     //now draw inner cut
 
     let inner_style = "#A9A9A9";
@@ -225,19 +279,19 @@ function drawCut(cut){
         inner_style = renderProofTexture(inner_style);
     }
 
-    CONTEXT.save();
-    CONTEXT.globalAlpha = 0.7;
-    CONTEXT.fillStyle = inner_style;
-    CONTEXT.beginPath();
-    CONTEXT.ellipse(
+    context.save();
+    context.globalAlpha = 0.7;
+    context.fillStyle = inner_style;
+    context.beginPath();
+    context.ellipse(
         cut.x, cut.y, 
         cut.rad_x - cut.border_rad, 
         cut.rad_y - cut.border_rad, 0, 0, 2 * Math.PI
     );
 
-    CONTEXT.fill();
-    CONTEXT.restore();
-    CONTEXT.lineWidth = 1;
+    context.fill();
+    context.restore();
+    context.lineWidth = 1;
 }
 
 

--- a/src/cut.js
+++ b/src/cut.js
@@ -49,6 +49,8 @@ class Cut{
             this.rad_x*2,this.rad_y*2
         ];
 
+        this.bounded_area = this.bounding_box[2] * this.bounding_box[3];
+
         let inner_bb = getInteriorBoundingBox(this.rad_x, this.rad_y);
         let diff_x = (this.rad_x * 2) - (inner_bb[0] * 2);
         let diff_y = (this.rad_y * 2) - (inner_bb[1] * 2);
@@ -88,6 +90,7 @@ class Cut{
             this.rad_x*2,this.rad_y*2
         ];
 
+        this.bounded_area = this.bounding_box[2] * this.bounding_box[3];
 
         let inner_bb = getInteriorBoundingBox(this.rad_x, this.rad_y);
         let diff_x = (this.rad_x * 2) - (inner_bb[0] * 2);

--- a/src/lib/math.js
+++ b/src/lib/math.js
@@ -128,6 +128,7 @@ function getInteriorBoundingBox(rad_x,rad_y){
 	return [ rad_x / Math.sqrt(2), rad_y / Math.sqrt(2) ];
 } 
 
+
 export {
 	transformPoint,
 	isWithinEllipse,

--- a/src/lib/math.js
+++ b/src/lib/math.js
@@ -107,6 +107,7 @@ function transformPoint(p, ratio){
 * gets the distance between two points
 * @param {Point} p1 
 * @param {Point} p2
+* @return {Number}
 */
 function getDistance(p1,p2){
 	let a = Math.pow( p2.x - p1.x,2 );
@@ -115,11 +116,24 @@ function getDistance(p1,p2){
 	return Math.sqrt( a + b );
 }
 
+
+/**
+* Given the x and y radius of an ecllipse, get the x,y values for
+* the largest rectange that can be inscribed inside of the ecllipse
+* @param {Number} rad_x
+* @param {Number} rad_y
+* @returns {Array.<Number>}
+*/
+function getInteriorBoundingBox(rad_x,rad_y){
+	return [ rad_x / Math.sqrt(2), rad_y / Math.sqrt(2) ];
+} 
+
 export {
 	transformPoint,
 	isWithinEllipse,
 	isWithinTollerance,
 	getEllipseArea,
 	getDistance,
-	isPointWithinRect
+	isPointWithinRect,
+	getInteriorBoundingBox,
 }

--- a/src/lib/vector.js
+++ b/src/lib/vector.js
@@ -32,10 +32,9 @@ class Vector{
 }
 
 /**
-*@param {Vector} v draws a given vector, primarlly for debugging
+* @param {Vector} v draws a given vector, primarily for debugging
 */
 function drawVector(v){
-
     let CONTEXT = CanvasManager.getInstance().getContext();
 
     CONTEXT.beginPath();

--- a/src/main.js
+++ b/src/main.js
@@ -4,7 +4,6 @@ import {UserInputManager, toggleMode} from './userInput.js';
 import {drawDistancesOfCuts} from './cutmanager.js';
 import {drawTemporaryCut, drawCut, getInnerMostCut} from './cut.js';
 import {drawSymbol} from './symbol.js';
-import {pack} from './subgraph.js';
 
 var DEBUG = true;
 
@@ -86,7 +85,7 @@ function renderLoop(){
             for(let x of c.child_cuts){
                 childs += x.toString() + "<br>";
             }
-            document.getElementById("debug").innerHTML = c.toString() +"<br>Level : " + c.level.toString() + childs;
+            document.getElementById("debug").innerHTML = c.toString() +"<br>Level : " + c.level.toString() + childs + "<br>" + c.bounded_area.toString();
         }
     }
 

--- a/src/main.js
+++ b/src/main.js
@@ -4,8 +4,9 @@ import {UserInputManager, toggleMode} from './userInput.js';
 import {drawDistancesOfCuts} from './cutmanager.js';
 import {drawTemporaryCut, drawCut, getInnerMostCut} from './cut.js';
 import {drawSymbol} from './symbol.js';
+import {pack} from './subgraph.js';
 
-var DEBUG = false;
+var DEBUG = true;
 
 window.onbeforeunload = () => {
     //save to browser before leaving
@@ -54,6 +55,8 @@ window.onload = () => {
     if(localStorage.getItem("save-state")){
         loadState("localStorage");
     }
+
+//    pack(CanvasManager.getInstance().cuts[0]);
 
     //start app
     renderLoop();

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,7 @@ import {drawDistancesOfCuts} from './cutmanager.js';
 import {drawTemporaryCut, drawCut, getInnerMostCut} from './cut.js';
 import {drawSymbol} from './symbol.js';
 
-var DEBUG = true;
+var DEBUG = false;
 
 window.onbeforeunload = () => {
     //save to browser before leaving

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -143,6 +143,23 @@ function renderProofTexture(inner_style){
     return scratch_ctx.createPattern(scratch, 'repeat');
 }
 
+/**
+* Draw a dot on the current opened canvas
+* @param {Point}
+* @param {Number|null} rad - radius of the dot, default 5
+* @param {String|null} col - color of the dot, default red
+*/
+function drawPoint(Point, rad = 10, col='red'){
+    let CM = CanvasManager.getInstance();
+    let context = CM.getContext();
+
+    context.beginPath();
+    context.fillStyle = col;
+    context.arc(Point.x,Point.y, rad, 0,2*Math.PI);
+    context.fill();
+}
+
+
 export {
     onResize,
     renderGrid,
@@ -150,5 +167,6 @@ export {
     fixBlur,
     displayError,
     displaySuccess,
-    renderProofTexture
+    renderProofTexture,
+    drawPoint
 }

--- a/src/subgraph.js
+++ b/src/subgraph.js
@@ -58,6 +58,8 @@ class Subgraph{
 			return true;
 		}
 
+		//TODO
+
 	}
 
 
@@ -74,6 +76,46 @@ class Subgraph{
 }
 
 
+function pack(cut){
+	//compress children first
+	for(const x of cut.child_cuts){
+		pack(x);
+	}
+
+
+	//if empty
+	if(cut.child_cuts.length === 0 && cut.child_syms.length === 0){
+		//set to default small size
+		cut.rad_x = 60;
+		cut.rad_y = 60;
+		return;
+	}
+
+
+	//get width & height of all inner cuts & symbols
+	const pad = 50;
+	let t_w = pad;
+	let t_h = pad;
+	for(let x of cut.child_cuts){
+		t_w += (2*x.rad_x);
+		t_h += (2*x.rad_y);
+	}
+
+	for(let x of cut.child_syms){
+		t_w += x.width;
+		t_h += x.width;
+	}
+
+	cut.rad_x = t_w/2;
+	cut.rad_y = t_h/2;
+
+	//make sure all elements are within the new cut
+
+
+}
+
+
 export{
-	Subgraph
+	Subgraph,
+	pack
 }

--- a/src/subgraph.js
+++ b/src/subgraph.js
@@ -1,4 +1,5 @@
 import {Cut} from './cut.js';
+import {Symbolic} from './symbol.js';
 import {getRandomString} from '../src/main.js';
 
 /**
@@ -17,6 +18,8 @@ class Subgraph{
 		//map the elements by what level they're on
 
 		this.levels = {};
+		this.free_symbols = [];
+		this.captured_symbols = [];
 
 		for(let x of this.elements){
 			if( typeof this.levels[x.level] === 'undefined' ){
@@ -25,11 +28,26 @@ class Subgraph{
 				let old = this.levels[x.level];
 				this.levels[old] = (old.push(x));
 			}
+
+
+			if (x instanceof Cut){
+				this.captured_symbols = this.captured_symbols.concat(x.child_syms);
+			}
+		}
+
+		for(let x of this.elements){
+			if (x instanceof Symbolic){
+				if(!this.captured_symbols.includes(x)){
+					this.free_symbols.push(x);
+				}
+			}
 		}
 	}
 
 
 	/**
+	* Calculate the real area of all the ellipses and free symbols in this subgraph
+	*
 	* @returns {Number}
 	*/
 	getArea(){
@@ -38,6 +56,29 @@ class Subgraph{
 			if(x instanceof Cut){
 				ret += x.area;
 			}
+		}
+		for(let x of this.free_symbols){
+			ret += x.area;
+		}
+		return ret;
+	}
+
+
+	/**
+	* Calculate area based on the outer bounding box of the cuts in this subgraph
+	*
+	* @returns {Number}
+	*/
+	getBoundedArea(){
+		let ret = 0;
+		for(let x of this.elements){
+			if(x instanceof Cut){
+				ret += x.bounded_area;
+			}
+		}
+
+		for(let x of this.free_symbols){
+			ret += x.area;
 		}
 		return ret;
 	}
@@ -76,46 +117,6 @@ class Subgraph{
 }
 
 
-function pack(cut){
-	//compress children first
-	for(const x of cut.child_cuts){
-		pack(x);
-	}
-
-
-	//if empty
-	if(cut.child_cuts.length === 0 && cut.child_syms.length === 0){
-		//set to default small size
-		cut.rad_x = 60;
-		cut.rad_y = 60;
-		return;
-	}
-
-
-	//get width & height of all inner cuts & symbols
-	const pad = 50;
-	let t_w = pad;
-	let t_h = pad;
-	for(let x of cut.child_cuts){
-		t_w += (2*x.rad_x);
-		t_h += (2*x.rad_y);
-	}
-
-	for(let x of cut.child_syms){
-		t_w += x.width;
-		t_h += x.width;
-	}
-
-	cut.rad_x = t_w/2;
-	cut.rad_y = t_h/2;
-
-	//make sure all elements are within the new cut
-
-
-}
-
-
 export{
 	Subgraph,
-	pack
 }

--- a/src/userInput.js
+++ b/src/userInput.js
@@ -234,6 +234,7 @@ function onKeyDown(e){
 
 
 function onKeyUp(e){
+    event.preventDefault();
     let UM = UserInputManager.getInstance();
     let CM = CanvasManager.getInstance();
     if ( e.code === "Escape" ){
@@ -243,9 +244,10 @@ function onKeyUp(e){
         UM.is_shift_down = false;
     }else if( isAlpha(e.code) && !UM.is_ctrl_down && e.code != "KeyR" && !UM.is_proof_mode){
         CM.addSymbol( new Symbolic(e.code[3], UM.mouse_pos ) );
-    }else if( e.code === "Delete" && !UM.is_proof_mode ){
+    }else if( (e.code === "Delete" || e.code === "Backspace") && !UM.is_proof_mode ){
         deleteObjectUnderMouse();
     }
+
 
     UM.is_shift_down = UM.is_ctrl_down = false;
     function isAlpha(tgt){
@@ -255,7 +257,7 @@ function onKeyUp(e){
         let n = tgt.charCodeAt(3);
         return n >=65 && n <= 90;
     }
-
+    e.stopPropagation();
 }
 
 


### PR DESCRIPTION
This PR adds work on inserting a subgraph into the main canvas from the scratch canvas. 
New behavior is improved than before but still incomplete:
Todo:
- [ ] when inserting a subgraph any existing elements in the target layer are ignored 
- [ ] bounding boxes aren't calculated correctly for symbols
- [ ] if the subgraph is larger than the existing layer, the target layer, its graph and the surrounding elements need to be scaled up
