### PR TITLE
Fix Creating new Cut on wrong level

### DIFF
--- a/src/cut.js
+++ b/src/cut.js
@@ -424,8 +424,8 @@ function drawTemporaryCut(pos){
     if ( CM.tmp_cut === null ){
         CM.tmp_origin = pos;
         CM.tmp_cut = new Cut(CM.tmp_origin);
-        CM.tmp_cut.rad_x = 1;
-        CM.tmp_cut.rad_y = 1;
+        CM.tmp_cut.rad_x = 0;
+        CM.tmp_cut.rad_y = 0;
     }
 
     let v = new Vector(CM.tmp_origin, pos);
@@ -446,6 +446,8 @@ function drawTemporaryCut(pos){
     context.globalAlpha = 0.5;
     drawCut(CM.tmp_cut);
     context.restore();
+
+    CM.tmp_cut.update();
 }
 
 


### PR DESCRIPTION
Fixes small bug where if creating a new cut, the default bounding box could potentially be larger than the parent cut and the newly created cut would be on the wrong level.

Now the bounding box on a tmp cut is recalculated when being drawn to make sure the parent cut is being calculated correctly 