### PR TITLE
Rework level calculation and improve double-cut + erasure rule logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 	<title>VisualLogic-Web</title>
 </head>
 
-<p id="debug" data-debug-mode="true" style="position: absolute;z-index: 999;top:50px;"></p>
+<p id="debug" data-debug-mode="false" style="position: absolute;z-index: 999;top:50px;"></p>
 
 <body>
 	<canvas id="canvas" width="100%"></canvas>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 	<title>VisualLogic-Web</title>
 </head>
 
-<p id="debug" data-debug-mode="false" style="position: absolute;z-index: 999;top:50px;"></p>
+<p id="debug" data-debug-mode="true" style="position: absolute;z-index: 999;top:50px;"></p>
 
 <body>
 	<canvas id="canvas" width="100%"></canvas>

--- a/src/canvasManager.js
+++ b/src/canvasManager.js
@@ -180,7 +180,7 @@ class __CanvasManager{
     recalculateCuts(){
         let CM = CanvasManager;
         for(let c of CM.getCuts()){
-            c.level = 1;
+            c.level = 0;
             c.child_syms = [];
             c.child_cuts = [];
         }
@@ -195,6 +195,7 @@ class __CanvasManager{
                 if( isRectInRect(i.bounding_box, j.bounding_box) ){
                     //J is within I
                     i.addChildCut(j);
+                    //an objects level is the number of cuts surronding it
                     j.level = i.level + 1;
                 }
             }
@@ -207,7 +208,7 @@ class __CanvasManager{
             for(let s of CM.getSyms()){
                 if( isWithinCut(s, c) ){
                     //add this to the innermost in this cut
-                    s.level = c.level;
+                    s.level = c.level + 1;
                     getInnerMostCutWithSymbol(c, s).addChildSym(s);
                 }
             }

--- a/src/cut.js
+++ b/src/cut.js
@@ -36,7 +36,7 @@ class Cut{
 
         this.child_cuts = [];
         this.child_syms = [];
-        this.level = 1;
+        this.level = 0;
 
         this.area = getEllipseArea(this.rad_x, this.rad_y);
 
@@ -58,6 +58,11 @@ class Cut{
             this.y - this.rad_y + diff_y/2,
             inner_bb[0]*2,inner_bb[1]*2
         ];
+    }
+
+
+    isEvenLevel(){
+        return this.level % 2 == 0;
     }
 
 
@@ -118,7 +123,7 @@ class Cut{
         }
 
         for ( let child of this.child_syms ){
-            if ( child.level === this.level ){
+            if ( child.level === this.level + 1){
                 child.updatePos(new_pos, false);
             }
         }
@@ -169,7 +174,7 @@ class Cut{
     */
     getChildren(){
         return this.child_cuts.filter(cut => cut.level === this.level+1).concat(
-            this.child_syms.filter(sym => sym.level === this.level));
+            this.child_syms.filter(sym => sym.level === this.level+1));
     }
 
 
@@ -236,7 +241,7 @@ class Cut{
     
         let inner_style = '#A9A9A9';
     
-        if(this.level % 2 === 0){
+        if(!this.isEvenLevel()){
             inner_style = 'white';
         }
     

--- a/src/subgraph.js
+++ b/src/subgraph.js
@@ -8,113 +8,12 @@ import {Symbolic} from './symbol.js';
 class Subgraph{
     /**
 	* @param {Array} parts
-	* @param {Cut|Symbol|null} root
 	*/ 
-    constructor(parts, root = null){
+    constructor(parts){
         this.elements = parts;
-        this.root = root === null ? parts[0] : root;
-        this.id = CanvasManager.getNextId();
-        //map the elements by what level they're on
-
-        this.levels = {};
-        this.free_symbols = [];
-        this.captured_symbols = [];
-
-        for(let x of this.elements){
-            if( typeof this.levels[x.level] === 'undefined' ){
-                this.levels[x.level] = [x];
-            }else{
-                let old = this.levels[x.level];
-                this.levels[old] = (old.push(x));
-            }
-
-
-            if (x instanceof Cut){
-                this.captured_symbols = this.captured_symbols.concat(x.child_syms);
-            }
-        }
-
-        for(let x of this.elements){
-            if (x instanceof Symbolic){
-                if(!this.captured_symbols.includes(x)){
-                    this.free_symbols.push(x);
-                }
-            }
-        }
+        
     }
 
-
-    /**
-	* Calculate the real area of all the ellipses and free symbols in this subgraph
-	*
-	* @returns {Number}
-	*/
-    getArea(){
-        return getAreaHelper(false, this);
-    }
-
-
-    /**
-	* Calculate area based on the outer bounding box of the cuts in this subgraph
-	*
-	* @returns {Number}
-	*/
-    getBoundedArea(){
-        return getAreaHelper(true, this);
-    }
-
-
-    isEqual(other){
-        /*
-		 check if every symbol has the same char, & same level
-		 each cut is on the same level and has same children
-		*/
-		
-        if(other.elements.length !== this.elements.length){
-            return false;
-        }
-
-
-        if(other.id === this.id){
-            return true;
-        }
-
-        //TODO
-
-    }
-
-
-    /**
-	* Create a text representation of this graph
-	*
-	* @returns {String}
-	*/
-    toString(){
-        throw 'TODO';
-    }
-
-}
-
-
-/**
- * Get the area of the subgraph
- * @param {Bool} is_bounded - get either bounded or real area
- * @param {Subgraph}
- * @returns {Number}
- */
-function getAreaHelper(is_bounded, subgraph){
-    let ret = 0;
-    for(let x of subgraph.elements){
-        if(x instanceof Cut){
-            ret += is_bounded ? x.bounded_area : x.area;
-        }
-    }
-
-    for(let x of subgraph.free_symbols){
-        ret += x.area;
-    }
-    
-    return ret;
 }
 
 

--- a/src/symbol.js
+++ b/src/symbol.js
@@ -28,7 +28,7 @@ class Symbolic{
         this.is_mouse_over = false;
 
         this.id = CanvasManager.getNextId();
-        this.level = 1;
+        this.level = 0;
 
         this.is_proof_selected = false;
 
@@ -37,6 +37,10 @@ class Symbolic{
 
     center(){
         return new Point(this.x,this.y);
+    }
+
+    isEvenLevel(){
+        return this.level % 2 == 0;
     }
 
     update(){

--- a/src/userInput.js
+++ b/src/userInput.js
@@ -4,7 +4,6 @@ import {getDeviceRatio, displayError} from './renderer.js';
 import {toggleMiniRenderer} from './minirenderer.js';
 import {CanvasManager} from './canvasManager.js';
 import {transformPoint} from './lib/math.js';
-import {Subgraph} from './subgraph.js';
 import {clearCanvas} from './main.js';
 import {Point} from './lib/point.js';
 import {Symbolic} from './symbol.js';
@@ -38,15 +37,15 @@ class __UserInputManager{
         document.getElementById('insert-btn').addEventListener('click', toggleMiniRenderer);
         document.getElementById('exit-mini').addEventListener('click', toggleMiniRenderer);
         document.getElementById('dbl-cut-btn').addEventListener('click', () => {
-            doubleCut( new Subgraph( CanvasManager.proof_selected) );
+            doubleCut( CanvasManager.proof_selected );
             toggleDoubleCutButton();
         });
         document.getElementById('insert-graph').addEventListener('click', () => {
             toggleMiniRenderer();
-            insertion( new Subgraph( CanvasManager.s_cuts.concat( CanvasManager.s_syms) ) );
+            insertion( CanvasManager.s_cuts.concat( CanvasManager.s_syms) );
         });
         document.getElementById('erasure-btn').addEventListener('click', () => {
-            erasure();
+            erasure( CanvasManager.proof_selected );
         });
         document.getElementById('iteration-btn').addEventListener('click', () => { displayError('not implemented'); });
         document.getElementById('deiteration-btn').addEventListener('click', () => { displayError('not implemented'); });
@@ -134,7 +133,7 @@ function getObjUnderMouse(){
     if(overSyms.length > 0){
         ret = overSyms[0];
     }else{
-        const overCuts = CM.getCuts().filter(cut => (cut.is_mouse_over || cut.is_mouse_in_border) && cut.level === 1);
+        const overCuts = CM.getCuts().filter(cut => (cut.is_mouse_over || cut.is_mouse_in_border) && cut.level === 0);
         if(overCuts.length > 0){
             const innerMost = mouseOverInnerMost(overCuts[0]);
             ret = innerMost.is_mouse_in_border ? innerMost.cut_border : innerMost;


### PR DESCRIPTION
The following PR corrects how a symbol or cut's level is calculated based on any cut surrounding it. Updates are now handled correctly by double cut and erasure rules.

Fixes and clean up some logic in double cut and erasure rules.

Removes most of subgraph class's functions and logic since it wasn't being used anywhere, instead, an array of cuts and symbols is passed into each logic rule 