### PR TITLE
Implement deiteration rule

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,6 @@
 	<script type="module" src="src/symbol.js"></script>
 	<script type="module" src="src/minirenderer.js"></script>
 	<script type="module" src="src/canvasManager.js"></script>
-	<script type="module" src="src/subgraph.js"></script>
 
 	<script type="module" src="src/lib/math.js"></script>
 	<script type="module" src="src/lib/point.js"></script>
@@ -22,7 +21,7 @@
 	<title>VisualLogic-Web</title>
 </head>
 
-<p id="debug" data-debug-mode="false" style="position: absolute;z-index: 999;top:50px;"></p>
+<p id="debug" data-debug-mode="true" style="position: absolute;z-index: 999;top:50px;"></p>
 
 <body>
 	<canvas id="canvas" width="100%"></canvas>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 	<title>VisualLogic-Web</title>
 </head>
 
-<p id="debug" data-debug-mode="true" style="position: absolute;z-index: 999;top:50px;"></p>
+<p id="debug" data-debug-mode="false" style="position: absolute;z-index: 999;top:50px;"></p>
 
 <body>
 	<canvas id="canvas" width="100%"></canvas>

--- a/src/canvasManager.js
+++ b/src/canvasManager.js
@@ -264,6 +264,12 @@ class __CanvasManager{
             }
         }
 
+        for(const x of this.syms){
+            if(x.is_proof_selected){
+                this.addProofSelected(x);
+            }
+        }
+
         return this.syms.concat(CanvasManager.cuts);
     }
 

--- a/src/canvasManager.js
+++ b/src/canvasManager.js
@@ -264,8 +264,8 @@ class __CanvasManager{
             }
         }
 
-        for(const x of this.syms){
-            if(x.is_proof_selected){
+        for (const x of this.syms){
+            if (x.is_proof_selected){
                 this.addProofSelected(x);
             }
         }

--- a/src/logic/ruleUtils.js
+++ b/src/logic/ruleUtils.js
@@ -36,16 +36,16 @@ function checkIfSubgraphsAreaEqual(first, second){
  */
 function checkSubgraphEqualByLevel(first, second){
 
-    for(const i of first.child_syms.sort()){
-        for(const j of second.child_syms.sort()){
+    for(const i of first.child_syms.sort((a,z) => a.id - z.id )){
+        for(const j of second.child_syms.sort((a,z) => a.letter.localCompare(z.letter) )){
             if( i.letter != j.letter ){
                 return false;
             }
         }
     }
 
-    for(const i of first.child_cuts.sort().filter(cut => cut.level === this.level+1)){
-        for(const j of second.child_cuts.sort().filter(cut => cut.level === this.level +1)){
+    for(const i of first.child_cuts.sort((a,z) => a.id - z.id).filter(cut => cut.level === this.level+1)){
+        for(const j of second.child_cuts.sort((a,z) => a.id - z.id).filter(cut => cut.level === this.level +1)){
             return checkSubgraphEqualByLevel(i,j);
         }
     }

--- a/src/logic/ruleUtils.js
+++ b/src/logic/ruleUtils.js
@@ -1,0 +1,59 @@
+import {Cut} from '../cut.js';
+import {Symbolic} from '../symbol.js';
+
+/**
+ * Check if two subgraphs are logically equal
+ * @param {Cut|Symbolic} first
+ * @param {Cut|Symbolic} second 
+ */
+function checkIfSubgraphsAreaEqual(first, second){
+    //check same types
+    if( ((first instanceof Cut) && (second instanceof Symbolic)) ||
+        ((first instanceof Symbolic) && (second instanceof Cut))){
+        return false;
+    }
+
+    if(first instanceof Symbolic){
+        return first.letter === second.letter;
+    }
+
+    //subgraphs should have same number of children
+    const child_syms = first.child_cuts.length === second.child_cuts.length;
+    const child_cuts = first.child_syms.length === second.child_syms.length;
+    if(!child_syms || !child_cuts){
+        return false;
+    }
+
+    return checkSubgraphEqualByLevel(first, second);
+}
+
+
+/**
+ * compare two subgraph's levels to check if they're the same and then move to the next level
+ * @param {Cut} first 
+ * @param {Cut} second 
+ * @returns bool
+ */
+function checkSubgraphEqualByLevel(first, second){
+
+    for(const i of first.child_syms.sort()){
+        for(const j of second.child_syms.sort()){
+            if( i.letter != j.letter ){
+                return false;
+            }
+        }
+    }
+
+    for(const i of first.child_cuts.sort().filter(cut => cut.level === this.level+1)){
+        for(const j of second.child_cuts.sort().filter(cut => cut.level === this.level +1)){
+            return checkSubgraphEqualByLevel(i,j);
+        }
+    }
+
+    return true;
+}
+
+
+export {
+    checkIfSubgraphsAreaEqual
+};

--- a/src/logic/ruleUtils.js
+++ b/src/logic/ruleUtils.js
@@ -4,23 +4,23 @@ import {Symbolic} from '../symbol.js';
 /**
  * Check if two subgraphs are logically equal
  * @param {Cut|Symbolic} first
- * @param {Cut|Symbolic} second 
+ * @param {Cut|Symbolic} second
  */
 function checkIfSubgraphsAreaEqual(first, second){
     //check same types
-    if( ((first instanceof Cut) && (second instanceof Symbolic)) ||
+    if ( ((first instanceof Cut) && (second instanceof Symbolic)) ||
         ((first instanceof Symbolic) && (second instanceof Cut))){
         return false;
     }
 
-    if(first instanceof Symbolic){
+    if (first instanceof Symbolic){
         return first.letter === second.letter;
     }
 
     //subgraphs should have same number of children
     const child_syms = first.child_cuts.length === second.child_cuts.length;
     const child_cuts = first.child_syms.length === second.child_syms.length;
-    if(!child_syms || !child_cuts){
+    if (!child_syms || !child_cuts){
         return false;
     }
 
@@ -30,22 +30,22 @@ function checkIfSubgraphsAreaEqual(first, second){
 
 /**
  * compare two subgraph's levels to check if they're the same and then move to the next level
- * @param {Cut} first 
- * @param {Cut} second 
+ * @param {Cut} first
+ * @param {Cut} second
  * @returns bool
  */
 function checkSubgraphEqualByLevel(first, second){
 
-    for(const i of first.child_syms.sort((a,z) => a.id - z.id )){
-        for(const j of second.child_syms.sort((a,z) => a.letter.localCompare(z.letter) )){
-            if( i.letter != j.letter ){
+    for (const i of first.child_syms.sort((a,z) => a.id - z.id )){
+        for (const j of second.child_syms.sort((a,z) => a.letter.localCompare(z.letter) )){
+            if ( i.letter != j.letter ){
                 return false;
             }
         }
     }
 
-    for(const i of first.child_cuts.sort((a,z) => a.id - z.id).filter(cut => cut.level === this.level+1)){
-        for(const j of second.child_cuts.sort((a,z) => a.id - z.id).filter(cut => cut.level === this.level +1)){
+    for (const i of first.child_cuts.sort((a,z) => a.id - z.id).filter(cut => cut.level === this.level+1)){
+        for (const j of second.child_cuts.sort((a,z) => a.id - z.id).filter(cut => cut.level === this.level +1)){
             return checkSubgraphEqualByLevel(i,j);
         }
     }

--- a/src/logic/rules.js
+++ b/src/logic/rules.js
@@ -97,17 +97,17 @@ function erasure(parts){
  * @param {Array} parts
  */
 function deiteration(parts){
-    if(parts.length !== 2){
-       return displayError("Must select two subgraphs to perform deiteration");
+    if (parts.length !== 2){
+        return displayError('Must select two subgraphs to perform deiteration');
     }
 
-    if(parts[0].level === parts[1].level){
-        return displayError("Deiteration can not be done between two subgraphs on the same level");
+    if (parts[0].level === parts[1].level){
+        return displayError('Deiteration can not be done between two subgraphs on the same level');
     }
 
     //the first element is the copy to delete
-    if(!checkIfSubgraphsAreaEqual(parts[0], parts[1])){
-        return displayError("Selected subgraphs are not equivalent");
+    if (!checkIfSubgraphsAreaEqual(parts[0], parts[1])){
+        return displayError('Selected subgraphs are not equivalent');
     }
 
     deleteObjectRecursive(parts[0]);

--- a/src/logic/rules.js
+++ b/src/logic/rules.js
@@ -101,6 +101,10 @@ function deiteration(parts){
        return displayError("Must select two subgraphs to perform deiteration");
     }
 
+    if(parts[0].level === parts[1].level){
+        return displayError("Deiteration can not be done between two subgraphs on the same level");
+    }
+
     //the first element is the copy to delete
     if(!checkIfSubgraphsAreaEqual(parts[0], parts[1])){
         return displayError("Selected subgraphs are not equivalent");

--- a/src/logic/rules.js
+++ b/src/logic/rules.js
@@ -1,3 +1,4 @@
+import {checkIfSubgraphsAreaEqual} from './ruleUtils.js';
 import {displaySuccess, displayError} from '../renderer.js';
 import {deleteObject, deleteObjectRecursive} from '../userInput.js';
 import {Cut} from '../cut.js';
@@ -14,18 +15,15 @@ import {Symbolic} from '../symbol.js';
 */
 function doubleCut(parts){
     if (parts.length !== 2){
-        displayError('Can only double cut between 2 immediate cuts');
-        return;
+        return displayError('Can only double cut between 2 immediate cuts');
     }
 
     if ( !(parts[0] instanceof Cut) || !(parts[1] instanceof Cut) ){
-        displayError('Can only perform double cut between two cuts');
-        return;
+        return displayError('Can only perform double cut between two cuts');
     }
 
     if ( parts[0].level == parts[1].level){
-        displayError('Cannot perform a double cut between cuts on the same level');
-        return;
+        return displayError('Cannot perform a double cut between cuts on the same level');
     }
 
     const err  = 'Can only perform double cut between two directly nested cuts with an empty subgraph in between them';
@@ -36,14 +34,12 @@ function doubleCut(parts){
     const child = parts[0].level > parts[1].level ? parts[0] : parts[1];
 
     if (parent.level != child.level-1){
-        displayError(err);
-        return;
+        return displayError(err);
     }
 
     for (const c of parent.getChildren()){
         if (c.id != child.id){
-            displayError(err);
-            return;
+            return displayError(err);
         }
     }
 
@@ -51,7 +47,7 @@ function doubleCut(parts){
     deleteObject(parent);
     deleteObject(child);
 
-    displaySuccess('Double cut complete');
+    return displaySuccess('Double cut complete');
 }
 
 
@@ -74,33 +70,49 @@ function insertion(){
 */
 function erasure(parts){
     if (parts.length !== 1){
-        displayError('Can only apply erasure to 1 subgraph at a time');
-        return;
+        return displayError('Can only apply erasure to 1 subgraph at a time');
     }
 
     const tgt = parts[0];
     if (tgt instanceof Symbolic){
         if (!tgt.isEvenLevel()){
-            displayError('Can only apply erasure to subgraph on an even level');
-            return;
+            return displayError('Can only apply erasure to subgraph on an even level');
         }
 
         deleteObject(tgt);
-        displaySuccess('Erasure Complete');
-        return;
+        return displaySuccess('Erasure Complete');
     }
 
     if (!tgt.isEvenLevel()){
-        displayError('Can only apply erasure to subgraph on an even level');
-        return;
+        return displayError('Can only apply erasure to subgraph on an even level');
     }
 
     deleteObjectRecursive(tgt);
-    displaySuccess('Erasure Complete');
+    return displaySuccess('Erasure Complete');
+}
+
+
+/**
+ * erase a copy of a subgraph at any nested level
+ * @param {Array} parts
+ */
+function deiteration(parts){
+    if(parts.length !== 2){
+       return displayError("Must select two subgraphs to perform deiteration");
+    }
+
+    //the first element is the copy to delete
+    if(!checkIfSubgraphsAreaEqual(parts[0], parts[1])){
+        return displayError("Selected subgraphs are not equivalent");
+    }
+
+    deleteObjectRecursive(parts[0]);
+    return displaySuccess('Erasure Complete');
 }
 
 export {
     doubleCut,
     insertion,
-    erasure
+    erasure,
+    deiteration
 };

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -109,11 +109,13 @@ function fixBlur(canvas, context, width, height){
 /** @param {String} message*/
 function displayError(message){
     displayMessage(message, true);
+    return false;
 }
 
 /** @param {String} message*/
 function displaySuccess(message){
     displayMessage(message, false);
+    return true;
 }
 
 /**
@@ -200,10 +202,7 @@ function renderDebugInfo(){
     const CM = CanvasManager;
     for ( const c of CM.getCuts() ){
         if ( c.is_mouse_over ){
-            let childs = '<br>Child Cuts : <br>';
-            for (const x of c.child_cuts){
-                childs += `${x.toString()}<br>`;
-            }
+            const childs = `<br>Child Cuts : ${c.child_cuts.length}`;
             document.getElementById('debug').innerHTML = `${c.toString()}<br>Level : ${c.level.toString()}${childs}<br>${c.bounded_area.toString()}`;
         }
     }

--- a/src/userInput.js
+++ b/src/userInput.js
@@ -16,13 +16,13 @@ class __UserInputManager{
 
         CM.Canvas.addEventListener('mousedown', onMouseDown);
         CM.Canvas.addEventListener('mouseup', onMouseUp);
-        CM.Canvas.addEventListener('mousemove', this.onMouseMove);
+        CM.Canvas.addEventListener('mousemove', onMouseMove);
         window.addEventListener('keydown', onKeyDown);
         window.addEventListener('keyup', onKeyUp);
 
         MiniCanvas.addEventListener('mousedown', onMouseDown);
         MiniCanvas.addEventListener('mouseup', onMouseUp);
-        MiniCanvas.addEventListener('mousemove', this.onMouseMove);
+        MiniCanvas.addEventListener('mousemove', onMouseMove);
 
         this.is_mouse_down = false;
         this.is_shift_down = false;
@@ -34,35 +34,49 @@ class __UserInputManager{
         this.obj_under_mouse = null;
         this.is_options_menu_open = false;
 
-        document.getElementById('toggle_mode').addEventListener('click', toggleMode);
-        document.getElementById('insert-btn').addEventListener('click', toggleMiniRenderer);
-        document.getElementById('exit-mini').addEventListener('click', toggleMiniRenderer);
+        this.toggle_mode_btn = document.getElementById('toggle_mode');
+        this.insert_btn = document.getElementById('insert-btn');
+        this.exit_mini_renderer_btn = document.getElementById('exit-mini');
+        this.double_cut_btn = document.getElementById('dbl-cut-btn');
+        this.insert_subgraph_btn = document.getElementById('insert-graph');
+        this.erasure_btn = document.getElementById('erasure-btn');
+        this.iteration_btn = document.getElementById('iteration-btn');
+        this.deiteration_btn = document.getElementById('deiteration-btn');
+        this.close_btn = document.getElementById('close-btn');
+        this.option_btn = document.getElementById('options-btn');
+        this.clear_btn = document.getElementById('clear-btn');
+
+        this.toggle_mode_btn.addEventListener('click', toggleMode);
+        this.insert_btn.addEventListener('click', toggleMiniRenderer);
+        this.exit_mini_renderer_btn.addEventListener('click', toggleMiniRenderer);
+
+        this.modal_background = document.getElementById('model-background');
 
         //rules
-        document.getElementById('dbl-cut-btn').addEventListener('click', () => {
+        this.double_cut_btn.addEventListener('click', () => {
             doubleCut( CanvasManager.proof_selected );
             toggleDoubleCutButton();
         });
-        document.getElementById('insert-graph').addEventListener('click', () => {
+
+        this.insert_subgraph_btn.addEventListener('click', () => {
             toggleMiniRenderer();
             insertion( CanvasManager.s_cuts.concat( CanvasManager.s_syms) );
         });
-        document.getElementById('erasure-btn').addEventListener('click', () => {
+
+        this.erasure_btn.addEventListener('click', () => {
             erasure( CanvasManager.proof_selected );
         });
-        document.getElementById('iteration-btn').addEventListener('click', () => { displayError('not implemented'); });
-        document.getElementById('deiteration-btn').addEventListener('click', () => { 
-            if(deiteration( CanvasManager.proof_selected )){ 
-                CM.removeProofSelected(CanvasManager.proof_selected[0]);
+
+        this.iteration_btn.addEventListener('click', () => { displayError('not implemented'); });
+        this.deiteration_btn.addEventListener('click', () => { 
+            if(deiteration( CM.proof_selected )){ 
+                CM.removeProofSelected(CM.proof_selected[0]);
             }
         });
 
-        document.getElementById('close-btn').addEventListener('click', toggleOptions);
-        document.getElementById('options-btn').addEventListener('click', toggleOptions);
-        document.getElementById('clear-btn').addEventListener('click', clearCanvas);
-
-        toggleProofButtons();
-        toggleOptions();
+        this.close_btn.addEventListener('click', toggleOptions);
+        this.option_btn.addEventListener('click', toggleOptions);
+        this.clear_btn.addEventListener('click', clearCanvas);
     }
 
     clearData(){
@@ -89,15 +103,17 @@ class __UserInputManager{
         this.obj_under_mouse = getObjUnderMouse();
     }
 
-    onMouseMove(e){
-        e.preventDefault();
-        e.stopPropagation();
+}
 
-        UserInputManager.mouse_pos = getRealMousePos(e);
 
-        //TODO find a better a time to figure this out
-        CanvasManager.recalculateCuts();
-    }
+function onMouseMove(e){
+    e.preventDefault();
+    e.stopPropagation();
+
+    UserInputManager.mouse_pos = getRealMousePos(e);
+
+    //TODO find a better a time to figure this out
+    CanvasManager.recalculateCuts();
 }
 
 
@@ -105,6 +121,9 @@ let UserInputManager;
 
 function InitializeUserInputManager(){
     UserInputManager = new __UserInputManager();
+    
+    toggleProofButtons();
+    toggleOptions();
 }
 
 
@@ -177,6 +196,7 @@ function getRealMousePos(pos){
 
 function onKeyDown(e){
     if ( e.code === 'ShiftLeft' || e.code === 'ShiftRight' ){
+        console.log('shift down');
         UserInputManager.is_shift_down = true;
     }
 }
@@ -201,9 +221,10 @@ function onKeyUp(e){
         CanvasManager.addSymbol( new Symbolic(e.code[3], UM.mouse_pos ) );
     } else if ( (e.code === 'Delete' || e.code === 'Backspace') && !UM.is_proof_mode ){
         deleteObjectUnderMouse();
+    } else if ( e.code === 'ShiftLeft' || e.code === 'ShiftRight' ){
+        UM.is_shift_down = false;
     }
 
-    UM.is_shift_down = false;
 }
 
 
@@ -291,26 +312,31 @@ function deleteObjectUnderMouse(){
 
 
     deleteObject(UM.obj_under_mouse);
+    UM.current_obj = null;
 }
 
 
 function toggleDoubleCutButton(){
-    document.getElementById('dbl-cut-btn').disabled = CanvasManager.proof_selected.length !== 2;
+    UserInputManager.double_cut_btn.disabled = CanvasManager.proof_selected.length !== 2;
+    UserInputManager.double_cut_btn.blur();
 }
 
 
 function toggleInsertionButton(){
-    document.getElementById('insert-btn').disabled = CanvasManager.proof_selected.length !== 1;
+    UserInputManager.insert_btn.disabled = CanvasManager.proof_selected.length !== 1;
+    UserInputManager.insert_btn.blur();
 }
 
 
 function toggleErasureButton(){
-    document.getElementById('erasure-btn').disabled = CanvasManager.proof_selected.length !== 1;
+    UserInputManager.erasure_btn.disabled = CanvasManager.proof_selected.length !== 1;
+    UserInputManager.erasure_btn.blur();
 }
 
 
 function toggleDeiterationButton(){
-    document.getElementById('deiteration-btn').disabled = CanvasManager.proof_selected.length !== 2;
+    UserInputManager.deiteration_btn.disabled = CanvasManager.proof_selected.length !== 2;
+    UserInputManager.deiteration_btn.blur();
 }
 
 function toggleProofButtons(){
@@ -320,10 +346,8 @@ function toggleProofButtons(){
     toggleDeiterationButton();
 }
 
-
 function toggleOptions(){
-    const tgt = document.getElementById('model-background');
-    tgt.style.display = tgt.style.display === 'flex' ? 'none' : 'flex';
+    UserInputManager.modal_background.style.display = UserInputManager.modal_background.style.display === 'flex' ? 'none' : 'flex';
 }
 
 export {

--- a/src/userInput.js
+++ b/src/userInput.js
@@ -68,8 +68,8 @@ class __UserInputManager{
         });
 
         this.iteration_btn.addEventListener('click', () => { displayError('not implemented'); });
-        this.deiteration_btn.addEventListener('click', () => { 
-            if(deiteration( CM.proof_selected )){ 
+        this.deiteration_btn.addEventListener('click', () => {
+            if (deiteration( CM.proof_selected )){
                 CM.removeProofSelected(CM.proof_selected[0]);
             }
         });
@@ -121,7 +121,7 @@ let UserInputManager;
 
 function InitializeUserInputManager(){
     UserInputManager = new __UserInputManager();
-    
+
     toggleProofButtons();
     toggleOptions();
 }

--- a/src/userInput.js
+++ b/src/userInput.js
@@ -1,4 +1,4 @@
-import {doubleCut, insertion, erasure} from './logic/rules.js';
+import {doubleCut, insertion, erasure, deiteration} from './logic/rules.js';
 import {getInnerMostCut} from './cut.js';
 import {getDeviceRatio, displayError} from './renderer.js';
 import {toggleMiniRenderer} from './minirenderer.js';
@@ -12,10 +12,11 @@ import {Symbolic} from './symbol.js';
 class __UserInputManager{
     constructor(){
         const MiniCanvas = CanvasManager.MiniCanvas;
+        const CM = CanvasManager;
 
-        CanvasManager.Canvas.addEventListener('mousedown', onMouseDown);
-        CanvasManager.Canvas.addEventListener('mouseup', onMouseUp);
-        CanvasManager.Canvas.addEventListener('mousemove', this.onMouseMove);
+        CM.Canvas.addEventListener('mousedown', onMouseDown);
+        CM.Canvas.addEventListener('mouseup', onMouseUp);
+        CM.Canvas.addEventListener('mousemove', this.onMouseMove);
         window.addEventListener('keydown', onKeyDown);
         window.addEventListener('keyup', onKeyUp);
 
@@ -36,6 +37,8 @@ class __UserInputManager{
         document.getElementById('toggle_mode').addEventListener('click', toggleMode);
         document.getElementById('insert-btn').addEventListener('click', toggleMiniRenderer);
         document.getElementById('exit-mini').addEventListener('click', toggleMiniRenderer);
+
+        //rules
         document.getElementById('dbl-cut-btn').addEventListener('click', () => {
             doubleCut( CanvasManager.proof_selected );
             toggleDoubleCutButton();
@@ -48,7 +51,12 @@ class __UserInputManager{
             erasure( CanvasManager.proof_selected );
         });
         document.getElementById('iteration-btn').addEventListener('click', () => { displayError('not implemented'); });
-        document.getElementById('deiteration-btn').addEventListener('click', () => { displayError('not implemented'); });
+        document.getElementById('deiteration-btn').addEventListener('click', () => { 
+            if(deiteration( CanvasManager.proof_selected )){ 
+                CM.removeProofSelected(CanvasManager.proof_selected[0]);
+            }
+        });
+
         document.getElementById('close-btn').addEventListener('click', toggleOptions);
         document.getElementById('options-btn').addEventListener('click', toggleOptions);
         document.getElementById('clear-btn').addEventListener('click', clearCanvas);
@@ -297,14 +305,19 @@ function toggleInsertionButton(){
 
 
 function toggleErasureButton(){
-    document.getElementById('erasure-btn').disabled =  CanvasManager.proof_selected.length !== 1;
+    document.getElementById('erasure-btn').disabled = CanvasManager.proof_selected.length !== 1;
 }
 
+
+function toggleDeiterationButton(){
+    document.getElementById('deiteration-btn').disabled = CanvasManager.proof_selected.length !== 2;
+}
 
 function toggleProofButtons(){
     toggleDoubleCutButton();
     toggleInsertionButton();
     toggleErasureButton();
+    toggleDeiterationButton();
 }
 
 


### PR DESCRIPTION
This PR implements the deiteration logic rule, allowing users to erase a subgraph based on a copy of a second subgraph that is nested at any level in relation to the first subgraph

Updates the functions in `rules.js` to return a boolean based on if the operation succeeds 

Refactors userInputManager so that the tgt HTML buttons are not found via `getElementById` each function call but cached in the `UserInputManager` on initialization.

Fixes bug where symbols that were proof selected were not correctly loaded back

Removes the subgraph class and file since it wasn't being used, the  functions in`rules.js`  just accepts  a list of Cuts and Symbols 